### PR TITLE
Fixed problem with app start

### DIFF
--- a/app/src/main/java/com/czura/recipes/model/rest/RestDataSource.java
+++ b/app/src/main/java/com/czura/recipes/model/rest/RestDataSource.java
@@ -2,7 +2,9 @@ package com.czura.recipes.model.rest;
 
 import com.czura.recipes.model.entities.ImageSize;
 import com.czura.recipes.model.entities.Recipe;
+import com.google.gson.GsonBuilder;
 
+import java.lang.reflect.Modifier;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -30,9 +32,12 @@ public class RestDataSource {
 
 //        client.interceptors().add(loggingInterceptor);
 
+        GsonBuilder builder = new GsonBuilder();
+        builder.excludeFieldsWithModifiers(Modifier.FINAL, Modifier.TRANSIENT, Modifier.STATIC);
+
         Retrofit recipesApiAdapter = new Retrofit.Builder()
                 .baseUrl(RecipesApi.END_POINT)
-                .addConverterFactory(GsonConverterFactory.create())
+                .addConverterFactory(GsonConverterFactory.create(builder.create()))
                 .client(client)
                 .build();
 


### PR DESCRIPTION
We had problem with app start, stacktrace below, fix included in this pull request

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.czura.recipes/com.czura.recipes.views.activities.MainActivity}: java.lang.IllegalArgumentException: Unable to create converter for java.util.List<com.czura.recipes.model.entities.Recipe>
   for method RecipesApi.getRecipes
   at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2416)
   at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476)
   at android.app.ActivityThread.-wrap11(ActivityThread.java)
   at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344)
   at android.os.Handler.dispatchMessage(Handler.java:102)
   at android.os.Looper.loop(Looper.java:148)
   at android.app.ActivityThread.main(ActivityThread.java:5417)
   at java.lang.reflect.Method.invoke(Native Method)
   at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
Caused by: java.lang.IllegalArgumentException: Unable to create converter for java.util.List<com.czura.recipes.model.entities.Recipe>
   for method RecipesApi.getRecipes
   at retrofit2.Utils.methodError(Utils.java:154)
   at retrofit2.MethodHandler.createResponseConverter(MethodHandler.java:62)
   at retrofit2.MethodHandler.create(MethodHandler.java:33)
   at retrofit2.Retrofit.loadMethodHandler(Retrofit.java:164)
   at retrofit2.Retrofit$1.invoke(Retrofit.java:145)
   at java.lang.reflect.Proxy.invoke(Proxy.java:393)
   at $Proxy2.getRecipes(Unknown Source)
   at com.czura.recipes.model.rest.RestDataSource.getRecipes(RestDataSource.java:49)
   at com.czura.recipes.mvp.presenters.RecipesListPresenter.downloadRecipes(RecipesListPresenter.java:92)
   at com.czura.recipes.mvp.presenters.RecipesListPresenter.onCreate(RecipesListPresenter.java:80)
   at com.czura.recipes.views.activities.MainActivity.initializePresenter(MainActivity.java:89)
   at com.czura.recipes.views.activities.MainActivity.onCreate(MainActivity.java:69)    
   at android.app.Activity.performCreate(Activity.java:6251)
   at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1107)
   at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2369)
   ... 9 more
Caused by: java.lang.SecurityException: Can't make field constructor accessible
   at java.lang.reflect.Constructor.setAccessible(Constructor.java:334)
   at com.google.gson.internal.ConstructorConstructor.newDefaultConstructor(ConstructorConstructor.java:97)
   at com.google.gson.internal.ConstructorConstructor.get(ConstructorConstructor.java:79)
   at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:96)
   at com.google.gson.Gson.getAdapter(Gson.java:360)
   at com.google.gson.internal.bind.MapTypeAdapterFactory.getKeyAdapter(MapTypeAdapterFactory.java:140)
   at com.google.gson.internal.bind.MapTypeAdapterFactory.create(MapTypeAdapterFactory.java:125)
   at com.google.gson.Gson.getAdapter(Gson.java:360)
   at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getFieldAdapter(ReflectiveTypeAdapterFactory.java:136)
   at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.access$100(ReflectiveTypeAdapterFactory.java:49)
   at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.<init>(ReflectiveTypeAdapterFactory.java:106)
   at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.createBoundField(ReflectiveTypeAdapterFactory.java:105)
   at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:161)
   at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:97)
   at com.google.gson.Gson.getAdapter(Gson.java:360)
   at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getFieldAdapter(ReflectiveTypeAdapterFactory.java:136)
   at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.access$100(ReflectiveTypeAdapterFactory.java:49)
```
